### PR TITLE
Don't cache data arrays to prevent OOM

### DIFF
--- a/dhybridrpy/data.py
+++ b/dhybridrpy/data.py
@@ -356,22 +356,26 @@ class Data(BaseProperties):
     @property
     def data(self) -> Union[np.ndarray, da.Array]:
         """Retrieve the data at each grid point."""
-        if self.name not in self._data_dict:
+        # If data was set programmatically (e.g. by arithmetic operators),
+        # return the cached result since there is no HDF5 file to re-read.
+        if self.name in self._data_dict:
+            return self._data_dict[self.name]
 
-            def loader():
-                with h5py.File(self.file_path, "r") as f:
-                    return f["DATA"][:].T
+        # Otherwise, always re-read from HDF5 without caching to avoid OOM
+        # when iterating over many timesteps.
+        def loader():
+            with h5py.File(self.file_path, "r") as f:
+                return f["DATA"][:].T
 
-            if self.lazy:
-                delayed_obj = delayed(loader)()
-                self._data_dict[self.name] = da.from_delayed(
-                    delayed_obj,
-                    shape=self._get_data_shape(),
-                    dtype=self._get_data_dtype(),
-                )
-            else:
-                self._data_dict[self.name] = loader()
-        return self._data_dict[self.name]
+        if self.lazy:
+            delayed_obj = delayed(loader)()
+            return da.from_delayed(
+                delayed_obj,
+                shape=self._get_data_shape(),
+                dtype=self._get_data_dtype(),
+            )
+        else:
+            return loader()
 
     @property
     def xdata(self) -> Union[np.ndarray, da.Array]:


### PR DESCRIPTION
## Summary

- The `Data.data` property previously cached the full HDF5 data array in `_data_dict`. When iterating over hundreds of timesteps, each `Field`/`Phase` object held its entire array forever, causing out-of-memory errors on large grids (e.g. 15000x3000 floats = 360 MB each).
- Changed the `data` property to always re-read from HDF5 (or recompute via dask) without caching the array in `_data_dict`.
- Derived objects created by arithmetic operators (`+`, `-`, `*`, `/`, `**`) and NumPy ufuncs still cache their computed results, since they have no HDF5 file to re-read from. This is detected by checking if `self.name in self._data_dict` (set by `_create_new_instance`).
- Small metadata (coordinate limits, computed coordinates, shape, dtype) remains cached as before.
